### PR TITLE
Fix UST card variants.

### DIFF
--- a/tools/download_set.R
+++ b/tools/download_set.R
@@ -17,7 +17,7 @@ download_set <- function(set,
 download_set_cards <- function(set) {
   cards <- list()
   for (s in set) {
-    next_page_url <- sprintf("https://api.scryfall.com/cards/search?q=set:%s", s)
+    next_page_url <- sprintf("https://api.scryfall.com/cards/search?unique=prints&q=set:%s", s)
     while(TRUE) {
       result <- jsonlite::fromJSON(next_page_url, simplifyVector = FALSE)
       cards <- append(cards, result$data)


### PR DESCRIPTION
This should fix downloading for Unstable card variants, which have unique rules text for some cards. This fix makes draftpod accurately simulate a draft cube environment, which would likely have all the variants accounted for.
(I was unable to run the R code on my own machine however, so generating the updated json is an exercise for a future commit unfortunately.)